### PR TITLE
Allow users to wrap a Transport around a preexisting net.Conn

### DIFF
--- a/raidman.go
+++ b/raidman.go
@@ -74,6 +74,18 @@ func DialTimeout(network, addr string, timeout time.Duration) (*Client, error) {
 	return c, nil
 }
 
+// Provide a means for users who can't use Dial, or don't want a Client, to
+// build their own Transport; TCP version.
+func WrapTCPConn(conn *net.TCPConn) (TcpTransport) {
+	return TcpTransport{conn}
+}
+
+// Provide a means for users who can't use Dial, or don't want a Client, to
+// build their own Transport; UDP version.
+func WrapUDPConn(conn *net.UDPConn) (UdpTransport) {
+	return UdpTransport{conn}
+}
+
 // eventToPbEvent translates a raidman.Event into a lowlevel protocol Event.
 func eventToPbEvent(event *Event) (*proto.Event, error) {
 	var e proto.Event

--- a/raidman.go
+++ b/raidman.go
@@ -74,14 +74,14 @@ func DialTimeout(network, addr string, timeout time.Duration) (*Client, error) {
 	return c, nil
 }
 
-// Provide a means for users who can't use Dial, or don't want a Client, to
-// build their own Transport; TCP version.
+// WrapTCPConn provides a means for users who can't use Dial, or don't want a Client, to
+// build their own TcpTransport.
 func WrapTCPConn(conn *net.TCPConn) (TcpTransport) {
 	return TcpTransport{conn}
 }
 
-// Provide a means for users who can't use Dial, or don't want a Client, to
-// build their own Transport; UDP version.
+// WrapUDPConn provides a means for users who can't use Dial, or don't want a Client, to
+// build their own UdpTransport.
 func WrapUDPConn(conn *net.UDPConn) (UdpTransport) {
 	return UdpTransport{conn}
 }


### PR DESCRIPTION
Allow users to create their own Transports, wrapping their own connections.

- While the `ReadMsg` and `WriteMsg` interfaces on `Transport` are public, there currently isn't any way for a library user to actually get a handle on a `Transport`. This makes the public status of these interfaces somewhat pointless. (With `rwc` being private, neither a `TcpTransport` nor a `UdpTransport` can be directly created).
- The only available codepaths go through `Dial`, which assumes that the user intends to open a new connection; should they be, say, using a preopened socket passed into the process by a superserver, the library is not currently useful.